### PR TITLE
Random quotes around my name fixed on user page

### DIFF
--- a/users/hamiltop.textile
+++ b/users/hamiltop.textile
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: “Peter Hamilton”
+title: "Peter Hamilton"
 username: hamiltop
-fullname: “Peter Hamilton”
+fullname: "Peter Hamilton"
 ---
 Peter Hamilton seems to do everything.
 


### PR DESCRIPTION
Somehow I put curly quotes into the source instead of straight quotes.  No idea how that happened, or why it makes a difference.
