### PR TITLE
Add link to slack organization sign up to the main navigation

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,6 +25,7 @@
         <li><a href="/lunches">Lunches</a></li>
         <li><a href="/sponsors">Sponsors</a></li>
         <li><a href="http://github.com/urug">GitHub</a></li>
+        <li><a href="http://urug.herokuapp.com/">Slack</a></li>
         <li><a href="/companies">Companies</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
This adds a link to a landing page where people can sign up to join our slack community. 